### PR TITLE
feat: Add pool metadata

### DIFF
--- a/contracts/amm.clar
+++ b/contracts/amm.clar
@@ -26,7 +26,8 @@
         token-0: principal,
         token-1: principal,
         fee: uint,
-
+        name: (string-ascii 64),
+        description: (string-ascii 128),
         liquidity: uint,
         balance-0: uint,
         balance-1: uint
@@ -47,7 +48,7 @@
 ;; create-pool
 ;; Creates a new pool with the given token-0, token-1, and fee
 ;; Ensures that a pool with these two tokens and given fee amount does not already exist
-(define-public (create-pool (token-0 <ft-trait>) (token-1 <ft-trait>) (fee uint)) 
+(define-public (create-pool (token-0 <ft-trait>) (token-1 <ft-trait>) (fee uint) (name (string-ascii 64)) (description (string-ascii 128))) 
     (let (
         ;; Create a pool-info tuple with the information
         (pool-info {
@@ -69,6 +70,8 @@
             token-0: token-0-principal,
             token-1: token-1-principal,
             fee: (get fee pool-info),
+            name: name,
+            description: description,
             liquidity: u0, ;; initially, liquidity is 0
             balance-0: u0, ;; initially, balance-0 (x) is 0
             balance-1: u0 ;; initially, balance-1 (y) is 0
@@ -422,4 +425,13 @@
 
 (define-private (min (a uint) (b uint)) 
     (if (< a b) a b)
+)
+
+(define-read-only (get-pool-metadata (pool-id (buff 20)))
+    (let
+        (
+            (pool-data (unwrap! (map-get? pools pool-id) (err u0)))
+        )
+        (ok { name: (get name pool-data), description: (get description pool-data) })
+    )
 )

--- a/frontend/components/create-pool.tsx
+++ b/frontend/components/create-pool.tsx
@@ -8,6 +8,8 @@ export function CreatePool() {
   const [token0, setToken0] = useState("");
   const [token1, setToken1] = useState("");
   const [fee, setFee] = useState(500);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
 
   return (
     <div className="flex flex-col max-w-md w-full gap-4 p-6 border border-gray-500 rounded-md">
@@ -44,9 +46,29 @@ export function CreatePool() {
           onChange={(e) => setFee(parseInt(e.target.value))}
         />
       </div>
+      <div className="flex flex-col gap-1">
+        <span className="font-bold">Name</span>
+        <input
+          type="text"
+          className="border-2 border-gray-500 rounded-lg px-4 py-2 text-black"
+          placeholder="Pool Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="font-bold">Description</span>
+        <input
+          type="text"
+          className="border-2 border-gray-500 rounded-lg px-4 py-2 text-black"
+          placeholder="Pool Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
 
       <button
-        onClick={() => handleCreatePool(token0, token1, fee)}
+        onClick={() => handleCreatePool(token0, token1, fee, name, description)}
         className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
       >
         Create Pool

--- a/frontend/components/pools.tsx
+++ b/frontend/components/pools.tsx
@@ -8,8 +8,10 @@ export interface PoolsListProps {
 export function PoolsList({ pools }: PoolsListProps) {
   return (
     <div className="flex flex-col">
-      <div className="grid grid-cols-4 place-items-center w-full bg-gray-900 justify-between p-4 font-semibold">
+      <div className="grid grid-cols-6 place-items-center w-full bg-gray-900 justify-between p-4 font-semibold">
         <span>ID</span>
+        <span>Name</span>
+        <span>Description</span>
         <span>Token Pair</span>
         <span>Fee</span>
         <span>Liquidity</span>
@@ -30,8 +32,10 @@ export function PoolListItem({ pool }: { pool: Pool }) {
   const feesInPercentage = pool.fee / 10_000;
 
   return (
-    <div className="grid grid-cols-4 place-items-center w-full bg-gray-800 justify-between p-4">
+    <div className="grid grid-cols-6 place-items-center w-full bg-gray-800 justify-between p-4">
       <span>{pool.id}</span>
+      <span>{pool.name}</span>
+      <span>{pool.description}</span>
       <div className="flex items-center gap-2">
         <Link
           href={`https://explorer.hiro.so/txid/${pool["token-0"]}?chain=testnet`}

--- a/frontend/hooks/use-stacks.ts
+++ b/frontend/hooks/use-stacks.ts
@@ -41,10 +41,16 @@ export function useStacks() {
     setUserData(null);
   }
 
-  async function handleCreatePool(token0: string, token1: string, fee: number) {
+  async function handleCreatePool(
+    token0: string,
+    token1: string,
+    fee: number,
+    name: string,
+    description: string
+  ) {
     try {
       if (!userData) throw new Error("User not connected");
-      const options = await createPool(token0, token1, fee);
+      const options = await createPool(token0, token1, fee, name, description);
       await openContractCall({
         ...options,
         appDetails,

--- a/tests/amm.test.ts
+++ b/tests/amm.test.ts
@@ -155,13 +155,39 @@ describe("AMM Tests", () => {
       })
     );
   });
+
+  it("creates a pool with metadata", () => {
+    const { result } = createPool("My Pool", "This is a test pool.");
+    expect(result).toBeOk(Cl.bool(true));
+
+    const { result: poolId } = getPoolId();
+    const { result: metadata } = simnet.callReadOnlyFn(
+      "amm",
+      "get-pool-metadata",
+      [poolId],
+      alice
+    );
+
+    expect(metadata).toBeOk(
+      Cl.tuple({
+        name: Cl.stringAscii("My Pool"),
+        description: Cl.stringAscii("This is a test pool."),
+      })
+    );
+  });
 });
 
-function createPool() {
+function createPool(name?: string, description?: string) {
   return simnet.callPublicFn(
     "amm",
     "create-pool",
-    [mockTokenOne, mockTokenTwo, Cl.uint(500)],
+    [
+      mockTokenOne,
+      mockTokenTwo,
+      Cl.uint(500),
+      Cl.stringAscii(name || "test-pool"),
+      Cl.stringAscii(description || "test-description"),
+    ],
     alice
   );
 }


### PR DESCRIPTION
## Summary
This PR adds support for **pool metadata (name + description)** in the AMM project.

### Changes Made
1. **contracts/amm.clar**
   - Extended the `pools` map to include `name` and `description`.
   - Updated `create-pool` to accept metadata as parameters.
   - Added a new read-only function `get-pool-metadata(pool-id)`.

2. **tests/amm.test.ts**
   - Added `"creates a pool with metadata"` test case.
   - Updated helpers to support metadata arguments.

3. **frontend/lib/amm.ts**
   - Extended Pool type with `name` and `description`.
   - Updated `createPool` to accept metadata.
   - Added `getPoolMetadata` function.
   - Updated `getAllPools` to include metadata.

4. **frontend/components/**
   - `create-pool.tsx`: added form inputs for `name` and `description`.
   - `pools.tsx`: now displays pool metadata.

### Verification
- I recommend running:
  ```bash
  clarinet test
